### PR TITLE
Allow "error" logging level to be used

### DIFF
--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -54,7 +54,7 @@ function formatter(id, level) {
 module.exports = function logging (server, conf) {
   var level = conf.logging && conf.logging.level && LOG_LEVELS.indexOf(conf.logging.level)
   if (level === undefined || level === -1 ) {
-    console.log('Warning, logging.level configured to an invalid value:', conf.logging.level)
+    console.log('Warning, logging.level configured to an invalid value:', level)
     console.log('Should be one of:', LOG_LEVELS.join(', '))
     level = DEFAULT_LEVEL
   }

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -52,8 +52,8 @@ function formatter(id, level) {
 }
 
 module.exports = function logging (server, conf) {
-  var level = conf.logging && conf.logging.level && LOG_LEVELS.indexOf(conf.logging.level) || DEFAULT_LEVEL
-  if (level === -1) {
+  var level = conf.logging && conf.logging.level && LOG_LEVELS.indexOf(conf.logging.level)
+  if (level === undefined || level === -1 ) {
     console.log('Warning, logging.level configured to an invalid value:', conf.logging.level)
     console.log('Should be one of:', LOG_LEVELS.join(', '))
     level = DEFAULT_LEVEL


### PR DESCRIPTION
`conf.logging.level: 'error'` was not previously accessible because the declaration would fallback to `DEFAULT_LEVEL` where `['error', ...].index('error')` returns a falsey value.