### PR TITLE
add config.gossip.autoPopulate to allow disable of auto build of peer table

### DIFF
--- a/plugins/gossip/init.js
+++ b/plugins/gossip/init.js
@@ -11,8 +11,8 @@ module.exports = function (gossip, config, server) {
   ;(isArray(seeds)  ? seeds : [seeds]).filter(Boolean)
   .forEach(function (addr) { gossip.add(addr, 'seed') })
 
-  // populate peertable with pub announcements on the feed
-  if(!config.gossip || config.gossip.pub !== false)
+  // populate peertable with pub announcements on the feed (allow this to be disabled via config)
+  if(!config.gossip || (config.gossip.autoPopulate !== false && config.gossip.pub !== false))
     pull(
       server.messagesByType({
         type: 'pub', live: true, keys: false


### PR DESCRIPTION
It is currently not possible to control which peers get added to the gossip table because this is generated deep inside the gossip plugin.

**This PR adds the config option `gossip.autoPopulate` that when set to false, prevents the peer table from automatically being populated from `{type: 'pub'}` messages, allowing the instance to manually populate however they want.**

An example of where this is needed is if you want to exclude adding blocked pubs to the peer table.