### PR TITLE
add ssb-ooo as default plugin

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -59,6 +59,7 @@ if (argv[0] == 'start') {
     .use(require('ssb-query'))
     .use(require('ssb-ws'))
     .use(require('ssb-ebt'))
+    .use(require('ssb-ooo'))
   // add third-party plugins
   require('./plugins/plugins').loadUserPlugins(createSsbServer, config)
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ssb-friends": "^3.1.3",
     "ssb-keys": "^7.1.1",
     "ssb-links": "^3.0.2",
+    "ssb-ooo": "^1.1.0",
     "ssb-query": "^2.1.0",
     "ssb-ref": "^2.13.9",
     "ssb-ws": "^5.1.1",


### PR DESCRIPTION
This PR adds `ssb-ooo` to the default plugin list. Now we can have out of order message support on all the pubs (assuming they update).

closes #600 

---

I am having trouble running the tests on macOS (test/invite.js is failing because the codes are being generated as external ipv6 address for some reason). Can @ahdinosaur do the honours of merging and pushing out a new release? (or anyone else for that matter!)