### PR TITLE
Add friends config option to connect to peers marked as friends

### DIFF
--- a/plugins/gossip/schedule.js
+++ b/plugins/gossip/schedule.js
@@ -166,6 +166,11 @@ function (gossip, config, server) {
 
       var connectedFriends = peers.filter(and(isConnect, isFriend)).length
 
+      if(conf('friends', true))
+        connect(peers, ts, 'friends', isFriend, {
+          quota: 3, factor: 2e3, max: 10*min, groupMin: 1e3,
+        })
+
       if(conf('seed', true))
         connect(peers, ts, 'seeds', isSeed, {
           quota: 3, factor: 2e3, max: 10*min, groupMin: 1e3,
@@ -231,20 +236,20 @@ function (gossip, config, server) {
     if(timer.unref) timer.unref()
   }
 
-    pull(
-      gossip.changes(),
-      pull.drain(function (ev) {
-        if(ev.type == 'disconnect')
-          connections()
-      }, function () {
-        console.warn('[gossip/dc] warning: this can happen if the database closes', arguments)
-      })
-    )
+  pull(
+    gossip.changes(),
+    pull.drain(function (ev) {
+      if(ev.type == 'disconnect')
+        connections()
+    }, function () {
+      console.warn('[gossip/dc] warning: this can happen if the database closes', arguments)
+    })
+  )
 
-    var int = setInterval(connections, 2e3)
-    if(int.unref) int.unref()
+  var int = setInterval(connections, 2e3)
+  if(int.unref) int.unref()
 
-    connections()
+  connections()
 
   return function onClose () {
     closed = true
@@ -260,6 +265,3 @@ exports.isLocal = isLocal
 exports.isFriend = isFriend
 exports.isConnectedOrConnecting = isConnect
 exports.select = select
-
-
-


### PR DESCRIPTION
This plays well with [ssb-friend-pub](https://github.com/ssbc/ssb-friend-pub) module. 

I reused the "friends" type for adding these peers so that friend-pub also should work together with the global module and prioritize friends.

The idea with this flag is that one should be able to only connect to peers marked as friends.