### PR TITLE
ssbc.github.io scuttlebot links fix

### DIFF
--- a/api.html
+++ b/api.html
@@ -16,7 +16,7 @@
       <a class="topnav-item " href="/patchwork" title="Patchwork">
       Patchwork<br><small>Social Messaging App</small>
     </a>
-      <a class="topnav-item " href="/scuttlebot" title="Scuttlebot">
+      <a class="topnav-item " href="/ssb-server" title="Scuttlebot">
       Scuttlebot<br><small>P2P Log Store</small>
     </a>
       <a class="topnav-item selected" href="/docs" title="Documentation">
@@ -47,29 +47,29 @@
       <div class="leftnav-item">API Documentation</div>
       <div class="leftnav-subitems">
         <div class="leftnav-item selected">
-      <a href="/scuttlebot/api.html" title="scuttlebot">scuttlebot</a>
+      <a href="/ssb-server/api.html" title="scuttlebot">scuttlebot</a>
     </div>
         <div class="leftnav-indent">
           <div class="leftnav-item ">
-      <a href="/scuttlebot/plugins/blobs.html" title="blobs">blobs</a>
+      <a href="/ssb-server/plugins/blobs.html" title="blobs">blobs</a>
     </div>
           <div class="leftnav-item ">
-      <a href="/scuttlebot/plugins/block.html" title="block">block</a>
+      <a href="/ssb-server/plugins/block.html" title="block">block</a>
     </div>
           <div class="leftnav-item ">
-      <a href="/scuttlebot/plugins/friends.html" title="friends">friends</a>
+      <a href="/ssb-server/plugins/friends.html" title="friends">friends</a>
     </div>
           <div class="leftnav-item ">
-      <a href="/scuttlebot/plugins/gossip.html" title="gossip">gossip</a>
+      <a href="/ssb-server/plugins/gossip.html" title="gossip">gossip</a>
     </div>
           <div class="leftnav-item ">
-      <a href="/scuttlebot/plugins/invite.html" title="invite">invite</a>
+      <a href="/ssb-server/plugins/invite.html" title="invite">invite</a>
     </div>
           <div class="leftnav-item ">
-      <a href="/scuttlebot/plugins/private.html" title="private">private</a>
+      <a href="/ssb-server/plugins/private.html" title="private">private</a>
     </div>
           <div class="leftnav-item ">
-      <a href="/scuttlebot/plugins/replicate.html" title="replicate">replicate</a>
+      <a href="/ssb-server/plugins/replicate.html" title="replicate">replicate</a>
     </div>
         </div>
         <div class="leftnav-item ">

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       <a class="topnav-item " href="/patchwork" title="Patchwork">
       Patchwork<br><small>Social Messaging App</small>
     </a>
-      <a class="topnav-item selected" href="/scuttlebot" title="Scuttlebot">
+      <a class="topnav-item selected" href="/ssb-server" title="Scuttlebot">
       Scuttlebot<br><small>P2P Log Store</small>
     </a>
       <a class="topnav-item " href="/docs" title="Documentation">
@@ -27,7 +27,7 @@
       <div id="layout">
         <div id="leftnav">
       <div class="leftnav-item selected">
-      <a href="/scuttlebot" title="Scuttlebot">Scuttlebot</a>
+      <a href="/ssb-server" title="Scuttlebot">Scuttlebot</a>
     </div>
       <div class="leftnav-subitems">
         <div class="leftnav-item ">
@@ -43,10 +43,10 @@
       <div class="leftnav-item">Examples</div>
       <div class="leftnav-subitems">
         <div class="leftnav-item ">
-      <a href="/ssb-blessed-dashboard" title="Blessed Dashboard">Blessed Dashboard</a>
+      <a href="/ssb-cli-dashboard" title="Blessed Dashboard">Blessed Dashboard</a>
     </div>
         <div class="leftnav-item ">
-      <a href="/ssb-example-whois" title="Example "Whois"">Example "Whois"</a>
+      <a href="/ssb-simple-whois" title="Example "Whois"">Example "Whois"</a>
     </div>
         <div class="leftnav-item ">
       <a href="/ssb-example-pm" title="Private Message">Private Message</a>
@@ -106,7 +106,7 @@ In the background, it syncs with known peers.
 Peers do not have to be trusted, and can share logs and files on behalf of other peers, as each log is an unforgeable append-only message feed.
 This means Scuttlebots comprise a <a href="https://en.wikipedia.org/wiki/Gossip_protocol">global gossip-protocol mesh</a> without any host dependencies.</p>
 <p><strong>Join us in #scuttlebutt on freenode.</strong></p>
-<p><a href="http://travis-ci.org/ssbc/scuttlebot"><img src="https://secure.travis-ci.org/ssbc/scuttlebot.png" alt="build status"></a></p>
+<p><a href="http://travis-ci.org/ssbc/ssb-server"><img src="https://secure.travis-ci.org/ssbc/ssb-server.png" alt="build status"></a></p>
 <h2 id="example-usage">Example Usage</h2>
 <pre><code class="lang-bash"># In bash:
 


### PR DESCRIPTION
scuttlebot has migrated to ssb-server, links in the docs website broke. This should fix some of them.

/docs/scuttlebot pages are unaffected