### PR TITLE
Fix shrinkwrap

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -465,6 +465,7 @@
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -1456,6 +1457,468 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4378,9 +4841,9 @@
       }
     },
     "ssb-config": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.2.0.tgz",
-      "integrity": "sha512-sto2MJHFujecasFzPpSITtiUXcuGqM8APIBHj4vWCibu2uAjKvYu4TPEUzFSdFCmWskVqfK3dTSGJK4CIPuGNQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.2.2.tgz",
+      "integrity": "sha512-fDBovNheFSf5M/2cW5Y6HJ5n8NbUGNOoLKbGilRuP/CKSygYqLhsW2qS3IBvnvMTi/uOEhQI6wwfmY5sQ6vynA==",
       "requires": {
         "deep-extend": "^0.6.0",
         "lodash.get": "^4.4.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4902,9 +4902,9 @@
       }
     },
     "ssb-ebt": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.3.7.tgz",
-      "integrity": "sha512-oaiCry/pgt5lQb6J5zdsnqiZcO5RgYAt9dcyP+mzhyxQxX1je2kA5FQ8HTXK8D7YuP1T5L8+z8cXmrhuEyr0WA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.3.8.tgz",
+      "integrity": "sha512-RF9HNJi5k2fiZKK9E2pP464UvH+Vi14VMaflfSIst8GD7LHiTEEN0eX1nqtR85/P0pUvLAkKkyCtfuqpnyzhqw==",
       "requires": {
         "base64-url": "^2.2.0",
         "epidemic-broadcast-trees": "^6.3.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,12 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "optional": true
-    },
     "abstract-leveldown": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
@@ -471,7 +465,6 @@
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -1459,29 +1452,10 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
-    "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
-      "optional": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.6.tgz",
-      "integrity": "sha512-BalK54tfK0pMC0jQFb2oHn1nz7JNQD/2ex5pBnCHgBi2xG7VV0cAOGy2RS2VbCqUXx5/6obMrMcQTJ8yjcGzbg==",
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1686,24 +1660,6 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "optional": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
-    "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
-      "optional": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
-    },
     "increment-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
@@ -1713,6 +1669,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
       "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+      "dev": true
+    },
+    "infer-partial-order": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/infer-partial-order/-/infer-partial-order-0.1.1.tgz",
+      "integrity": "sha1-t3rCJudv1/N6ju3YXY1NbpeRJX4=",
       "dev": true
     },
     "inflight": {
@@ -1738,6 +1700,16 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
       "integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y="
+    },
+    "interleavings": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/interleavings/-/interleavings-0.3.1.tgz",
+      "integrity": "sha1-besjBJ3YfL4L7MAZCh7OBHedAtM=",
+      "dev": true,
+      "requires": {
+        "infer-partial-order": "~0.1.1",
+        "rng": "~0.2.2"
+      }
     },
     "ip": {
       "version": "1.1.5",
@@ -2431,24 +2403,6 @@
         "is-plain-obj": "^1.1.0"
       }
     },
-    "minipass": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-      "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
-      "optional": true,
-      "requires": {
-        "minipass": "^2.2.1"
-      }
-    },
     "mixin-deep": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
@@ -2697,17 +2651,6 @@
         "semver": "^5.4.1"
       }
     },
-    "needle": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
-      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
-      "optional": true,
-      "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      }
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -2727,24 +2670,6 @@
       "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==",
       "optional": true
     },
-    "node-pre-gyp": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
-      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
-      }
-    },
     "non-private-ip": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
@@ -2757,16 +2682,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-    },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "optional": true,
-      "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
-      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -2792,22 +2707,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.1.tgz",
       "integrity": "sha512-bui9/kzRGymbkxJsZEBZgDHK2WJWGOHzR0pCr404EpkpVFTkCOYaRwQTlehUE+7oI70mWNENncCWqUxT/icfHw=="
-    },
-    "npm-bundled": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
-      "optional": true
-    },
-    "npm-packlist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.2.0.tgz",
-      "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
-      "optional": true,
-      "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
-      }
     },
     "npm-prefix": {
       "version": "1.2.0",
@@ -3174,6 +3073,26 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz",
       "integrity": "sha1-cBephMO4NN53usOMELd28i38GEM="
+    },
+    "pull-bitflipper": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/pull-bitflipper/-/pull-bitflipper-0.1.0.tgz",
+      "integrity": "sha1-rGaxvyWd/qK/BOcMGOfYwgfXAx0=",
+      "dev": true,
+      "requires": {
+        "pull-stream": "~2.27.0"
+      },
+      "dependencies": {
+        "pull-stream": {
+          "version": "2.27.0",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.27.0.tgz",
+          "integrity": "sha1-/fDrkQzcQEHWWVbAC+4w270AoGg=",
+          "dev": true,
+          "requires": {
+            "pull-core": "~1.1.0"
+          }
+        }
+      }
     },
     "pull-box-stream": {
       "version": "1.0.13",
@@ -4020,6 +3939,18 @@
         }
       }
     },
+    "rng": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/rng/-/rng-0.2.2.tgz",
+      "integrity": "sha1-30PoDZvIKtRDC8/vA/SccX6LLow=",
+      "dev": true
+    },
+    "run-series": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
+      "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg==",
+      "dev": true
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4032,18 +3963,6 @@
       "requires": {
         "ret": "~0.1.10"
       }
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "optional": true
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "optional": true
     },
     "secret-handshake": {
       "version": "1.1.16",
@@ -4059,9 +3978,9 @@
       }
     },
     "secret-stack": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-5.1.0.tgz",
-      "integrity": "sha512-lCY0Oad4BYSKDlMbVXNEZEF8qVTbz2tNB7oNdlZAFg7k558Njq/bCx5MEj9GWmc+n+GhnxAXQYB5+CX1+0v4iQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.0.1.tgz",
+      "integrity": "sha512-MdHEFYloAkE7BtXYMCF03o8q5UaJDCfA2OLakt5rauaVXkUl0xDD9FC4/VjmzuA7+BxmQIkgIiG0bI0cg3PfgQ==",
       "requires": {
         "debug": "^4.1.0",
         "hoox": "0.0.1",
@@ -4472,9 +4391,9 @@
       }
     },
     "ssb-db": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-18.6.5.tgz",
-      "integrity": "sha512-/4nFP7yj1JD5jrwX9bHG2nipBefl++xXXbNWD14eL+Ohs3X8kdmJeBKnHgiIF7Je4HQOI31OmEIdyyLKum5niQ==",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-19.0.1.tgz",
+      "integrity": "sha512-HXr1gD5w0jpwTQO5+8POjvgQd0Sv+1xJrcG3DGab3K+ptXSPDQSaxxh7CD0nPw8ahts6Lvzsoc/K+X6OAowiiw==",
       "requires": {
         "async-write": "^2.1.0",
         "cont": "~1.0.0",
@@ -4484,21 +4403,39 @@
         "flumeview-hashtable": "^1.0.3",
         "flumeview-level": "^3.0.5",
         "flumeview-reduce": "^1.3.9",
-        "level": "^4.0.0",
-        "level-sublevel": "^6.6.2",
         "ltgt": "^2.2.0",
+        "mdmanifest": "^1.0.8",
         "monotonic-timestamp": "~0.0.8",
+        "muxrpc-validation": "^3.0.0",
         "obv": "0.0.1",
         "pull-cont": "^0.1.1",
-        "pull-level": "^2.0.3",
-        "pull-live": "^1.0.1",
-        "pull-paramap": "^1.1.6",
         "pull-stream": "^3.4.0",
         "ssb-keys": "^7.1.3",
         "ssb-msgs": "^5.0.0",
         "ssb-ref": "^2.12.0",
         "ssb-validate": "^4.0.0",
         "typewiselite": "^1.0.0"
+      },
+      "dependencies": {
+        "muxrpc-validation": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.0.tgz",
+          "integrity": "sha1-47bAMaetOA8CrWfZMG1PGz+NNdY=",
+          "requires": {
+            "pull-stream": "^2.28.3",
+            "zerr": "^1.0.1"
+          },
+          "dependencies": {
+            "pull-stream": {
+              "version": "2.28.4",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
+              "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
+              "requires": {
+                "pull-core": "~1.1.0"
+              }
+            }
+          }
+        }
       }
     },
     "ssb-ebt": {
@@ -4526,6 +4463,72 @@
         "pull-notify": "^0.1.1",
         "pull-stream": "^3.6.0",
         "ssb-ref": "^2.7.1"
+      }
+    },
+    "ssb-generate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-generate/-/ssb-generate-1.0.1.tgz",
+      "integrity": "sha1-Txconc3miluOsPALkTV3Cyy4qEU=",
+      "dev": true,
+      "requires": {
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.0"
+      }
+    },
+    "ssb-gossip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ssb-gossip/-/ssb-gossip-1.0.3.tgz",
+      "integrity": "sha512-PpvMB2ZrFTnvB7BzVc6ulljukdw83HRMN/6yUXL2zwMYUEWbfH1Z18mZSWLbk8rkxlpOdH4i5cslxuq/eIek/A==",
+      "requires": {
+        "atomic-file": "^1.1.5",
+        "deep-equal": "^1.0.1",
+        "ip": "^1.1.5",
+        "mdmanifest": "^1.0.8",
+        "muxrpc-validation": "^3.0.0",
+        "on-change-network": "0.0.2",
+        "on-wakeup": "^1.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-ping": "^2.0.2",
+        "pull-stream": "^3.6.9",
+        "ssb-ref": "^2.13.9",
+        "statistics": "^3.3.0"
+      },
+      "dependencies": {
+        "muxrpc-validation": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.0.tgz",
+          "integrity": "sha1-47bAMaetOA8CrWfZMG1PGz+NNdY=",
+          "requires": {
+            "pull-stream": "^2.28.3",
+            "zerr": "^1.0.1"
+          },
+          "dependencies": {
+            "pull-stream": {
+              "version": "2.28.4",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
+              "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
+              "requires": {
+                "pull-core": "~1.1.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "ssb-invite": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.0.3.tgz",
+      "integrity": "sha512-oFUIYfxWe2xcNCns5aH5MEDSBmbH3N9WvXlhbM05SqMO/0au6VMXvUDKD1VALVunU1FVPzMAcS0/YsVlLS8ang==",
+      "requires": {
+        "cont": "^1.0.3",
+        "explain-error": "^1.0.4",
+        "ip": "^1.1.5",
+        "level": "^4.0.0",
+        "level-sublevel": "^6.6.5",
+        "mdmanifest": "^1.0.8",
+        "ssb-client": "^4.6.0",
+        "ssb-keys": "^7.1.3",
+        "ssb-ref": "^2.13.9"
       }
     },
     "ssb-keys": {
@@ -4636,6 +4639,24 @@
         "is-canonical-base64": "^1.1.1",
         "is-valid-domain": "~0.0.1",
         "multiserver-address": "^1.0.1"
+      }
+    },
+    "ssb-replicate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.0.4.tgz",
+      "integrity": "sha512-N27WG2Ug2o+r1kEIgWVo8iVdUZqRAQtSHCg7TKQ0YXzUiyoglHlTCJUynGTcXNiB04RRo1DtVaPXdZ74ZJ4Dtg==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "mdmanifest": "^1.0.8",
+        "observ-debounce": "^1.1.1",
+        "obv": "0.0.1",
+        "pull-cat": "^1.1.11",
+        "pull-next": "^1.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-paramap": "^1.2.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.9",
+        "ssb-ref": "^2.13.9"
       }
     },
     "ssb-validate": {
@@ -4810,21 +4831,6 @@
             "path-is-absolute": "^1.0.0"
           }
         }
-      }
-    },
-    "tar": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
-      "optional": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.4",
-        "minizlib": "^1.1.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
       }
     },
     "tar-fs": {
@@ -5292,11 +5298,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     },
     "yargs-parser": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ssb-client": "^4.5.7",
     "ssb-config": "^3.0.0",
     "ssb-db": "^19.0.0",
-    "ssb-ebt": "^5.3.7",
+    "ssb-ebt": "^5.3.8",
     "ssb-friends": "^3.1.12",
     "ssb-gossip": "^1.0.3",
     "ssb-invite": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,3 @@
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT"
 }
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   "scripts": {
     "start": "node bin server",
     "prepublishOnly": "npm ls && npm test",
-    "test": "set -e; for t in test/*.js; do echo TEST $t; node $t; done && ./test/deps.sh"
+    "test": "set -e; npm ls --package-lock && for t in test/*.js; do echo TEST $t; node $t; done && ./test/deps.sh",
+    "reinstall": "rm -rf node_modules && npm install --package-lock && npm shrinkwrap"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "git://github.com/ssbc/ssb-server.git"
   },
   "dependencies": {
-    "atomic-file": "^1.1.5",
     "bash-color": "~0.0.3",
     "broadcast-stream": "^0.2.1",
     "cont": "~1.0.3",
@@ -26,18 +25,10 @@
     "muxrpc-validation": "^2.0.0",
     "muxrpcli": "^1.0.0",
     "mv": "^2.1.1",
-    "observ-debounce": "^1.1.1",
-    "obv": "0.0.1",
-    "on-change-network": "0.0.2",
-    "on-wakeup": "^1.0.0",
     "osenv": "^0.1.5",
     "pull-cat": "~1.1.5",
     "pull-file": "^1.0.0",
     "pull-many": "~1.0.6",
-    "pull-next": "^1.0.0",
-    "pull-notify": "0.1.1",
-    "pull-paramap": "~1.2.1",
-    "pull-ping": "^2.0.2",
     "pull-pushable": "^2.2.0",
     "pull-stream": "^3.6.2",
     "rimraf": "^2.4.2",
@@ -57,7 +48,6 @@
     "ssb-ref": "^2.13.9",
     "ssb-replicate": "^1.0.4",
     "ssb-ws": "^5.1.1",
-    "statistics": "^3.0.0",
     "stream-to-pull-stream": "^1.6.10",
     "zerr": "^1.0.0"
   },
@@ -83,3 +73,7 @@
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT"
 }
+
+
+
+

--- a/test/deps.sh
+++ b/test/deps.sh
@@ -6,14 +6,20 @@ ln -s ../ ssb-server
 cd ..
 
 set -e
+
+name () {
+  while read r
+  do
+    echo "$1": $r
+  done
+}
+
 test () {
   echo "## TESTING DEPENDENCY: $1"
   pushd node_modules/$1
-  npm test
+  npm test | name $1
   popd
 }
-
-
 
 test ssb-friends
 test ssb-blobs


### PR DESCRIPTION
@christianbundy I propose we fix it this way.

* `npm ls` is part of tests, with `--package-lock` enabled in case package-lock is disabled, this makes npm respect `npm-shrinkwrap.json`, yes.
* `ssb-server` (or other distributions) are currectly expected to include dev deps on things they are running in `test/deps.sh`. We could have a script to update this, but I think it's okay for now.