### PR TITLE
Add pretest

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -465,6 +465,7 @@
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",
@@ -1456,6 +1457,487 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "optional": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2707,6 +3189,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.1.tgz",
       "integrity": "sha512-bui9/kzRGymbkxJsZEBZgDHK2WJWGOHzR0pCr404EpkpVFTkCOYaRwQTlehUE+7oI70mWNENncCWqUxT/icfHw=="
+    },
+    "npm-install-package": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
+      "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
+      "dev": true
     },
     "npm-prefix": {
       "version": "1.2.0",
@@ -4439,6 +4927,16 @@
               }
             }
           }
+        },
+        "ssb-validate": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-4.0.4.tgz",
+          "integrity": "sha512-MojZCR1qgZHdO4pnh4Loiqxj7fxP3w+MrA/4smXoKD46ReEnOjt/8Vm2sq3qpqPmUBU2GbEoDlgw7OKy0mWJBw==",
+          "requires": {
+            "is-canonical-base64": "^1.1.1",
+            "monotonic-timestamp": "0.0.9",
+            "ssb-ref": "^2.6.2"
+          }
         }
       }
     },
@@ -4665,11 +5163,11 @@
       }
     },
     "ssb-validate": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-4.0.4.tgz",
-      "integrity": "sha512-MojZCR1qgZHdO4pnh4Loiqxj7fxP3w+MrA/4smXoKD46ReEnOjt/8Vm2sq3qpqPmUBU2GbEoDlgw7OKy0mWJBw==",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-0.0.0.tgz",
+      "integrity": "sha1-a8XYZVn0nS/vqUbbmspMJR1mIlU=",
+      "dev": true,
       "requires": {
-        "is-canonical-base64": "^1.1.1",
         "monotonic-timestamp": "0.0.9",
         "ssb-ref": "^2.6.2"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -669,11 +669,11 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -2930,9 +2930,9 @@
       "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "multiblob": {
       "version": "1.13.3",
@@ -4062,6 +4062,14 @@
             "to-regex": "^3.0.1"
           },
           "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -4258,6 +4266,11 @@
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -4329,6 +4342,21 @@
         "vfile-find-up": "^1.0.0",
         "vfile-reporter": "^1.5.0",
         "ware": "^1.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "remark-html": {
@@ -4601,6 +4629,14 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -4616,6 +4652,11 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "start": "node bin start",
     "prepublishOnly": "npm test",
     "test": "rm node_modules/ssb-server; set -e; npm ls --package-lock && for t in test/*.js; do echo TEST $t; node $t; done && ./test/deps.sh",
-    "reinstall": "rm -rf node_modules && npm install --package-lock && npm shrinkwrap"
+    "reinstall": "rm -rf node_modules && npm install --package-lock && npm shrinkwrap",
+    "pretest": "./scripts/pretest.js"
   },
   "dependencies": {
     "bash-color": "~0.0.3",
@@ -65,9 +66,12 @@
     "cat-names": "^2.0.0",
     "dog-names": "~1.0.2",
     "interleavings": "^0.3.1",
+    "npm-install-package": "^2.1.0",
     "pull-bitflipper": "^0.1.0",
+    "rng": "^0.2.2",
     "run-series": "^1.1.8",
     "ssb-generate": "^1.0.1",
+    "ssb-validate": "0.0.0",
     "tape": "^4.9.1"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "broadcast-stream": "^0.2.1",
     "cont": "~1.0.3",
     "cross-spawn": "^6.0.5",
+    "debug": "^4.1.1",
     "deep-equal": "^1.0.1",
     "explain-error": "^1.0.3",
     "has-network": "0.0.1",
@@ -70,6 +71,7 @@
     "pull-bitflipper": "^0.1.0",
     "rng": "^0.2.2",
     "run-series": "^1.1.8",
+    "semver": "^5.6.0",
     "ssb-generate": "^1.0.1",
     "ssb-validate": "0.0.0",
     "tape": "^4.9.1"

--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -5,6 +5,19 @@ const semver = require('semver')
 const debug = require('debug')('ssb-server:pretest')
 var install = require('npm-install-package')
 
+// polyfill!
+if (!Object.entries) {
+  Object.entries = function( obj ){
+    var ownProps = Object.keys( obj ),
+        i = ownProps.length,
+        resArray = new Array(i); // preallocate the Array
+    while (i--)
+      resArray[i] = [ownProps[i], obj[ownProps[i]]];
+    
+    return resArray;
+  };
+}
+
 debug.enabled = true
 
 if (process.env.NODE_ENV != 'production') {

--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+const fs = require('fs')
+const path = require('path')
+const semver = require('semver')
+const debug = require('debug')('ssb-server')
+var install = require('npm-install-package')
+
+if (process.env.NODE_ENV != 'production') {
+
+  const plugins = [
+    'ssb-gossip',
+    'ssb-blobs',
+    'ssb-invite',
+    'ssb-replicate',
+    'ssb-ebt'
+  ]
+
+
+  // get dependencies from ssb-server
+  const fullPath = path.join(__dirname, '..', 'package.json')
+  debug('getting dependencies from %s', fullPath)
+  const package = JSON.parse(fs.readFileSync(fullPath))
+  const parent = {}
+  Object.entries(package.dependencies).forEach(e => parent[e[0]] = e[1])
+  Object.entries(package.devDependencies).forEach(e => parent[e[0]] = e[1])
+
+  // initialize empty array for new deps needed
+  const needDeps = []
+
+  // get dependencies from plugin directories
+  plugins.forEach(plugin => {
+    const fullPath = path.join(__dirname, '..', 'node_modules', plugin, 'package.json')
+    debug('getting dependencies from %s', fullPath)
+    const package = JSON.parse(fs.readFileSync(fullPath))
+    const pluginDeps = {}
+    Object.entries(package.devDependencies).forEach(e => pluginDeps[e[0]] = e[1])
+
+    Object.entries(pluginDeps).forEach(e => {
+      const [ k, v ] = e
+
+      if (Object.keys(parent).includes(k) === false) {
+        if (k !== 'ssb-server' ) {
+          if (needDeps[k] == null) {
+            debug('new dependency from %s: %o', plugin, { name: k, range: v })
+            needDeps[k] = v
+          } else {
+            const pairs = [
+              [needDeps[k], v],
+              [parent[k], [v]]
+            ]
+
+            pairs.forEach(pair => {
+              if (semver.intersects(pair[0], pair[1]) === false) {
+                throw new Error('plugins have incompatible devDependencies')
+              }
+            })
+          }
+        }
+      }
+    })
+  })
+
+  // 
+  const devDeps = Object.entries(needDeps).map(e => [e[0], e[1]].join('@'))
+
+  if (devDeps.length > 0) {
+    debug('installing: %O', devDeps)
+    var opts = { saveDev: true, cache: true }
+
+    install(devDeps, opts, function (err) {
+      if (err) throw err
+      debug('done!')
+    })
+  } else {
+    debug('plugin devDeps are already up-to-date!')
+  }
+}
+

--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -5,8 +5,9 @@ const semver = require('semver')
 const debug = require('debug')('ssb-server')
 var install = require('npm-install-package')
 
-if (process.env.NODE_ENV != 'production') {
+debug.enabled = true
 
+if (process.env.NODE_ENV != 'production') {
   const plugins = [
     'ssb-gossip',
     'ssb-blobs',
@@ -67,12 +68,18 @@ if (process.env.NODE_ENV != 'production') {
     debug('installing: %O', devDeps)
     var opts = { saveDev: true, cache: true }
 
+    debug.enabled = true
+    debug('installing new plugin devDependencies')
     install(devDeps, opts, function (err) {
       if (err) throw err
-      debug('done!')
+      // avoid tests passing via Travis CI if dependencies are out-of-date
+      debug('done! please re-run tests with these new dependencies')
+      process.exit(1)
     })
+
+
   } else {
-    debug('plugin devDeps are already up-to-date!')
+    debug('plugin devDeps look great!')
   }
 }
 

--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -2,7 +2,7 @@
 const fs = require('fs')
 const path = require('path')
 const semver = require('semver')
-const debug = require('debug')('ssb-server')
+const debug = require('debug')('ssb-server:pretest')
 var install = require('npm-install-package')
 
 debug.enabled = true

--- a/test/deps.sh
+++ b/test/deps.sh
@@ -20,9 +20,7 @@ test () {
   pushd node_modules/$1
   set -o pipefail
   npm test | name $1
-#  exit_status=${PIPESTATUS[0]}
   popd
- # exit $exit_status
 }
 
 test ssb-friends
@@ -30,8 +28,4 @@ test ssb-blobs
 test ssb-invite
 test ssb-replicate
 test ssb-ebt
-
-
-
-
 


### PR DESCRIPTION
@dominictarr 

If we're going to do it then we may as well automate it. Here's a first stab that runs before `npm test`:

1. Collect the list of dependencies from ssb-server's `package.json`
2. Collect the list of dependencies from each plugin
3. If a plugin devDependency is incompatible with ssb-server or another plugin, throw an error
4. If we have new devDependencies to install, install and exit 1 (to ensure bad commits don't pass test)

I think this is better than my previous suggestion of `npm install` because it was running after `npm ci` and messing with our determinism.

Resolves #625