### PR TITLE
Require ssb-master instead of non-existing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ var path = require('path')
 
 // add plugins
 Server
-  .use(require('ssb-server/plugins/master'))
+  .use(require('ssb-master'))
   .use(require('ssb-gossip'))
   .use(require('ssb-replicate'))
   .use(require('ssb-backlinks'))


### PR DESCRIPTION
The documentation states the use of `ssb-server/plugins/master` something that was broken out of ssb-server some time ago. This small fix here makes sure others don't trip over the same mistake I made ;)

Under the hood there's actually a significant difference between the commands 
`ssb-server start` and the JS example. It's perhaps not a bad idea to at least reference https://github.com/ssbc/ssb-server/blob/607808d37d75f92002c25bd80aa28fea9052479a/bin.js#L45-L62

(which is a nice list of plugins to get started with given one only takes what one needs).