### PR TITLE
upgrade ssb-blobs to 1.2.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6009,9 +6009,9 @@
       }
     },
     "ssb-blobs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.2.1.tgz",
-      "integrity": "sha512-3x21LBIo/TDdUVw3IPnMYyh3T31+i6Xw2v0WftiuY0djPkq3dfwQV11+t3AY6LBtKsN1jS1bpxaDZcM/npF9dA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.2.2.tgz",
+      "integrity": "sha512-N+X46lE/KaIH9y1w3LQ9pPnt2tQr5VCSj1dAo/pJGYnSwnHz8GhIiboq7UGzrCZwCWgVUs22/2YiytCXSC9ASg==",
       "requires": {
         "cont": "^1.0.3",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "pull-stream": "^3.6.2",
     "rimraf": "^2.4.2",
     "secret-stack": "^6.2.1",
-    "ssb-blobs": "1.2.1",
+    "ssb-blobs": "1.2.2",
     "ssb-caps": "^1.0.1",
     "ssb-client": "^4.7.5",
     "ssb-config": "^3.2.5",


### PR DESCRIPTION
Addresses the bug mentioned in `%zGIBPSlxKA1mPj8r7wJ7u9GjNKw1AD/q3BHdKQ3V7IY=.sha256`, where a bug in `ssb-blobs@1.2.1` affects patchfoo use.