### PR TITLE
Improve README organization and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It has:
  - File-synchronization
  - End-to-end encryption
 
-ssb-server behaves just like a [Kappa Architecture DB](http://www.kappa-architecture.com/).
+`ssb-server` behaves just like a [Kappa Architecture DB](http://www.kappa-architecture.com/).
 In the background, it syncs with known peers.
 Peers do not have to be trusted, and can share logs and files on behalf of other peers, as each log is an unforgeable append-only message feed.
 This means ssb-servers comprise a [global gossip-protocol mesh](https://en.wikipedia.org/wiki/Gossip_protocol) without any host dependencies.
@@ -20,42 +20,33 @@ If you are looking to use ssb-server to run a pub, consider using [ssb-minimal-p
 
 ## Install
 
-a known-working [shrinkwrapped](https://docs.npmjs.com/cli/shrinkwrap.html) version will be installed.
-
+To add `ssb-server` to your available CLI commands, install it using the `-g` global flag:
 ```
 npm install -g ssb-server
 ```
 
 ## Applications
 
-There are already several applications built on ssb-server,
+There are already several applications built on `ssb-server`,
 one of the best ways to learn about secure-scuttlebutt is to poke around in these applications.
 
 * [patchwork](http://github.com/ssbc/patchwork) is a discussion platform that we use to anything and everything concerning ssb and decentralization.
 * [patchbay](http://github.com/ssbc/patchbay) is another take on patchwork - it's compatible, less polished, but more modular. The main goal of patchbay is to be very easy to add features to.
 * [git-ssb](https://github.com/clehner/git-ssb) is git (& github!) on top of secure-scuttlebutt. Although we still keep our repos on github, primary development is via git-ssb.
 
-it is recommended to get started with patchwork, and then look into git-ssb and patchbay.
+It is recommended to get started with patchwork, and then look into git-ssb and patchbay.
 
-## Example Usage (bash)
+## Starting an `ssb-server`
+
+### Command Line Usage Example
+
+Start the server with extra log detail
+Leave this running in its own terminal/window
 ```bash
-# Start the server with extra log detail
-# Leave this running in its own terminal/window
 ssb-server start --logging.level=info
-
-# publish a message
-ssb-server publish --type post --text "My First Post!"
-
-# stream all messages in all feeds, ordered by publish time
-ssb-server feed
-
-# stream all messages in all feeds, ordered by receive time
-ssb-server log
-
-# stream all messages by one feed, ordered by sequence number
-ssb-server hist --id $FEED_ID
 ```
-## Example Usage (js)
+
+### Javascript Usage Example
 
 ```js
 var Server = require('ssb-server')
@@ -82,7 +73,33 @@ fs.writeFileSync(
 ```
 see: [github.com/ssbc/**ssb-config**](https://github.com/ssbc/ssb-config) for custom configuration.
 
-elsewhere: 
+## Calling `ssb-server` Functions
+
+There are a variety of ways to call `ssb-server` methods, from a command line as well as in a javascript program.
+
+### Command Line Usage Example
+
+The command `ssb-server` can also used to call the running `ssb-server`.
+
+Now, in a separate terminal from the one where you ran `ssb-server start`, you can run commands such as the following:
+```bash
+# publish a message
+ssb-server publish --type post --text "My First Post!"
+
+# stream all messages in all feeds, ordered by publish time
+ssb-server feed
+
+# stream all messages in all feeds, ordered by receive time
+ssb-server log
+
+# stream all messages by one feed, ordered by sequence number
+ssb-server hist --id $FEED_ID
+```
+
+### Javascript Usage Example
+
+Note that the following involves using a separate JS package, called [ssb-client](https://github.com/ssbc/ssb-client). It is most suitable for connecting to a running `ssb-server` and calling its methods. To see further distinctions between `ssb-server` and `ssb-client`, check out this [handbook article](https://handbook.scuttlebutt.nz/guides/ssb-server-context).
+
 ```js
 var pull = require('pull-stream')
 var Client = require('ssb-client')
@@ -129,18 +146,18 @@ Client(function (err, server) {
 })
 ```
 
-## Use-cases
+## Use Cases
 
-ssb-server's message-based data structure makes it ideal for mail and forum applications (see [Patchwork](https://ssbc.github.io/patchwork/)).
+`ssb-server`'s message-based data structure makes it ideal for mail and forum applications (see [Patchwork](https://ssbc.github.io/patchwork/)).
 However, it is sufficiently general to be used to build:
 
  - Office tools (calendars, document-sharing, tasklists)
  - Wikis
  - Package managers
 
-Because ssb-server doesn't depend on hosts, its users can synchronize over WiFi or any other connective medium, making it great for [Sneakernets](https://en.wikipedia.org/wiki/Sneakernet).
+Because `ssb-server` doesn't depend on hosts, its users can synchronize over WiFi or any other connective medium, making it great for [Sneakernets](https://en.wikipedia.org/wiki/Sneakernet).
 
-ssb-server is [eventually-consistent with peers](https://en.wikipedia.org/wiki/Eventual_consistency), and requires exterior coordination to create strictly-ordered transactions.
+`ssb-server` is [eventually-consistent with peers](https://en.wikipedia.org/wiki/Eventual_consistency), and requires exterior coordination to create strictly-ordered transactions.
 Therefore, by itself, it would probably make a poor choice for implementing a crypto-currency.
 (We get asked that a lot.)
 
@@ -148,8 +165,8 @@ Therefore, by itself, it would probably make a poor choice for implementing a cr
 
 ### Getting Started
 
-- [Install](https://ssbc.github.io/docs/scuttlebot/install.html) - Setup instructions
-- [Tutorial](https://ssbc.github.io/docs/scuttlebot/tutorial.html) - Primer on developing with ssb-server
+- [Install](https://handbook.scuttlebutt.nz/guides/ssb-server/install) - Setup instructions
+- [Tutorial](https://handbook.scuttlebutt.nz/guides/ssb-server/tutorial) - Primer on developing with ssb-server
 - [API / CLI Reference](https://scuttlebot.io/apis/scuttlebot/ssb.html) (out of date, but still the best reference)
 - [ssb-config](https://github.com/ssbc/ssb-config) - a module which helps build config to start ssb-server with
 - [ssb-client](https://github.com/ssbc/ssb-client) - make a remote connection to the server


### PR DESCRIPTION
I separated example usage docs into two headers: 

## Starting an `ssb-server`
and
## Calling `ssb-server` Functions

because I find it confusing when they're mixed. Then, each has a Bash, and JS section. This helps clarify a lot of things.