### PR TITLE
package.json: dep on sodium-native >=2.4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pull-stream": "^3.6.2",
     "rimraf": "^2.4.2",
     "secret-stack": "^6.3.1",
+    "sodium-native": "^2.4.9",
     "ssb-blobs": "1.2.2",
     "ssb-caps": "^1.0.1",
     "ssb-client": "^4.7.9",


### PR DESCRIPTION
sodium-native 2.4.2 does not build with nodejs 14.2.0 (compile errors reported during npm install of ssb-server).

Along with this patch, need to also update shrinkwrap and commit npm-shrinkwrap.json (I didn't do it, would rather a dev do it):

    npm install --save