### PR TITLE
Fix caps being interpreted as a Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var caps = require('ssb-caps')
 
 // create a sbot with default caps. these can be overridden again when you call create.
 function createSsbServer () {
-  return SecretStack({ caps: { shs: Buffer.from(caps.shs, 'base64') } })
+  return SecretStack({ caps })
     .use(require('ssb-db'))
 }
 module.exports = createSsbServer()


### PR DESCRIPTION
Problem: The SSB-Server configures `caps` as a buffer, which breaks all
connections because it's supposed to be a base64 string.

Solution: Use the base64 string just like we're doing in SSB-Config.