### PR TITLE
Updated config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Be sure to start the pub server from this script (as shown in step 10), as this 
   "connections": {
     "incoming": {
       "net": [
-        { "scope": "public", "host": "0.0.0.0", "external": ["Your Host Name or Public IP"], "transform": "shs", "port": 8008 }
+        { "scope": "public", "host": "0.0.0.0", "external": "Your Host Name or Public IP", "transform": "shs", "port": 8008 }
       ]
     },
     "outgoing": {


### PR DESCRIPTION

Fixes #728 - Changed external property in config example. The previous example used an array and led to issues creating invites on the first setup for newbies. The multiserver net plugin seems to call `replace()` on the external property, which does not work for arrays.